### PR TITLE
Fix live lectures visibility for all users

### DIFF
--- a/FIX_LIVE_LECTURES_VISIBILITY.sql
+++ b/FIX_LIVE_LECTURES_VISIBILITY.sql
@@ -1,0 +1,60 @@
+-- FIX: Live Lectures Only Showing in Admin App - Not for All Users
+-- 
+-- ISSUE: The original RLS policy used "FOR ALL" which was conflicting with the read permissions
+-- SOLUTION: Split the admin policy into separate INSERT, UPDATE, DELETE policies
+-- 
+-- Run this SQL script in your Supabase SQL Editor to fix the issue immediately
+
+-- Drop the existing admin policy that might be conflicting with read access
+DROP POLICY IF EXISTS "Allow admin users to manage live lectures" ON public.live_lectures;
+
+-- Recreate separate policies for admin operations
+-- This ensures the read policy (FOR SELECT) works independently
+
+-- Allow admin users to insert live lectures
+CREATE POLICY "Allow admin users to insert live lectures" ON public.live_lectures
+    FOR INSERT TO authenticated WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM auth.users 
+            WHERE auth.users.id = auth.uid() 
+            AND auth.users.raw_user_meta_data->>'role' = 'admin'
+        )
+    );
+
+-- Allow admin users to update live lectures
+CREATE POLICY "Allow admin users to update live lectures" ON public.live_lectures
+    FOR UPDATE TO authenticated USING (
+        EXISTS (
+            SELECT 1 FROM auth.users 
+            WHERE auth.users.id = auth.uid() 
+            AND auth.users.raw_user_meta_data->>'role' = 'admin'
+        )
+    ) WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM auth.users 
+            WHERE auth.users.id = auth.uid() 
+            AND auth.users.raw_user_meta_data->>'role' = 'admin'
+        )
+    );
+
+-- Allow admin users to delete live lectures
+CREATE POLICY "Allow admin users to delete live lectures" ON public.live_lectures
+    FOR DELETE TO authenticated USING (
+        EXISTS (
+            SELECT 1 FROM auth.users 
+            WHERE auth.users.id = auth.uid() 
+            AND auth.users.raw_user_meta_data->>'role' = 'admin'
+        )
+    );
+
+-- Verify the policies are correctly set
+-- The following should show:
+-- 1. "Allow authenticated users to read live lectures" (FOR SELECT)
+-- 2. "Allow admin users to insert live lectures" (FOR INSERT)  
+-- 3. "Allow admin users to update live lectures" (FOR UPDATE)
+-- 4. "Allow admin users to delete live lectures" (FOR DELETE)
+
+SELECT schemaname, tablename, policyname, permissive, roles, cmd, qual 
+FROM pg_policies 
+WHERE tablename = 'live_lectures' 
+ORDER BY cmd;

--- a/supabase/migrations/20250113000000_create_live_lectures_table.sql
+++ b/supabase/migrations/20250113000000_create_live_lectures_table.sql
@@ -23,9 +23,33 @@ ALTER TABLE public.live_lectures ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Allow authenticated users to read live lectures" ON public.live_lectures
     FOR SELECT TO authenticated USING (true);
 
--- Allow admin users to manage live lectures (insert, update, delete)
-CREATE POLICY "Allow admin users to manage live lectures" ON public.live_lectures
-    FOR ALL TO authenticated USING (
+-- Allow admin users to insert, update, and delete live lectures
+CREATE POLICY "Allow admin users to insert live lectures" ON public.live_lectures
+    FOR INSERT TO authenticated WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM auth.users 
+            WHERE auth.users.id = auth.uid() 
+            AND auth.users.raw_user_meta_data->>'role' = 'admin'
+        )
+    );
+
+CREATE POLICY "Allow admin users to update live lectures" ON public.live_lectures
+    FOR UPDATE TO authenticated USING (
+        EXISTS (
+            SELECT 1 FROM auth.users 
+            WHERE auth.users.id = auth.uid() 
+            AND auth.users.raw_user_meta_data->>'role' = 'admin'
+        )
+    ) WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM auth.users 
+            WHERE auth.users.id = auth.uid() 
+            AND auth.users.raw_user_meta_data->>'role' = 'admin'
+        )
+    );
+
+CREATE POLICY "Allow admin users to delete live lectures" ON public.live_lectures
+    FOR DELETE TO authenticated USING (
         EXISTS (
             SELECT 1 FROM auth.users 
             WHERE auth.users.id = auth.uid() 

--- a/supabase/migrations/20250113000001_fix_live_lectures_policies.sql
+++ b/supabase/migrations/20250113000001_fix_live_lectures_policies.sql
@@ -1,0 +1,42 @@
+-- Fix live lectures RLS policies to ensure all authenticated users can read live lectures
+-- while only admins can manage them
+
+-- Drop the existing admin policy that might be conflicting
+DROP POLICY IF EXISTS "Allow admin users to manage live lectures" ON public.live_lectures;
+
+-- Recreate separate policies for admin operations
+-- Allow admin users to insert live lectures
+CREATE POLICY "Allow admin users to insert live lectures" ON public.live_lectures
+    FOR INSERT TO authenticated WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM auth.users 
+            WHERE auth.users.id = auth.uid() 
+            AND auth.users.raw_user_meta_data->>'role' = 'admin'
+        )
+    );
+
+-- Allow admin users to update live lectures
+CREATE POLICY "Allow admin users to update live lectures" ON public.live_lectures
+    FOR UPDATE TO authenticated USING (
+        EXISTS (
+            SELECT 1 FROM auth.users 
+            WHERE auth.users.id = auth.uid() 
+            AND auth.users.raw_user_meta_data->>'role' = 'admin'
+        )
+    ) WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM auth.users 
+            WHERE auth.users.id = auth.uid() 
+            AND auth.users.raw_user_meta_data->>'role' = 'admin'
+        )
+    );
+
+-- Allow admin users to delete live lectures
+CREATE POLICY "Allow admin users to delete live lectures" ON public.live_lectures
+    FOR DELETE TO authenticated USING (
+        EXISTS (
+            SELECT 1 FROM auth.users 
+            WHERE auth.users.id = auth.uid() 
+            AND auth.users.raw_user_meta_data->>'role' = 'admin'
+        )
+    );


### PR DESCRIPTION
Splits the `live_lectures` RLS admin policy to enable all authenticated users to view live lectures.

The previous `FOR ALL` RLS policy for admins was inadvertently restricting read access to admins only, overriding the `FOR SELECT` policy for all authenticated users. This change ensures all authenticated users can view live lectures while maintaining admin-only management.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0fe9d17-0e0c-4e56-b010-a749483b1c33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0fe9d17-0e0c-4e56-b010-a749483b1c33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

